### PR TITLE
Revert "use cffi 1.11"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-smbus-cffi~=1.11
+smbus-cffi


### PR DESCRIPTION
This reverts commit 594cc50b6e28a34a12c0468ee6a68c6c9f82a515 to accommodate Raspbian, using the latest version for the platform.